### PR TITLE
child waiting fix

### DIFF
--- a/src/exec_utils_2.c
+++ b/src/exec_utils_2.c
@@ -75,9 +75,17 @@ int	exec_single_cmd(t_list *cmds, t_pipe *pipex, t_o_cmd *o_cmd, int prev_pip, t
 	return (0);
 }
 
+void	wait_commands(int nb_cmds) {
+	while (nb_cmds > 0) {
+		waitpid(-1, NULL, 0);
+		nb_cmds--;
+	}
+}
+
 int	exec_multiple_cmds(t_list **cmds, t_o_cmd **o_cmd, t_pipe *pipex, int *prev_pip, t_env_head *env_head)
 {
 	pid_t	pid;
+	int		nb_cmds = pipex->nbr_cmds;
 
 	while (pipex->nbr_cmds > 1)
 	{
@@ -97,5 +105,6 @@ int	exec_multiple_cmds(t_list **cmds, t_o_cmd **o_cmd, t_pipe *pipex, int *prev_
 		*prev_pip = pipex->pipe_fd[0];
 		next_cmdexe(cmds, o_cmd, pipex);
 	}
+	wait_commands(nb_cmds);
 	return (0);
 }

--- a/src/ft_env.c
+++ b/src/ft_env.c
@@ -31,11 +31,9 @@ char	*get_type_env(char *cmd)
 char *get_value_env(char *cmd)
 {
 	int	i;
-	int	j;
     char *res;
 
 	i = 0;
-	j = 0;
 	while (cmd[i] && cmd[i] != '=')
 		i++;
 	if (cmd[i] == '\0')

--- a/src/heredoc.c
+++ b/src/heredoc.c
@@ -23,10 +23,8 @@ void	close_fd(int sig)
 static void	creat_heredoc(t_list *cmds, t_env_head *env_head)
 {
 	char	*buffer;
-	char	*path_cmd;
 	int fd;
 
-	path_cmd = NULL;
 	// (void)env_head;
 	signal(SIGINT, close_fd);
 	signal(SIGQUIT, SIG_IGN); 


### PR DESCRIPTION
Les subprocess n'etaient pas attendus correctement, par exemple si tu faisais `sleep 1 | ls`, la commande finissait des que `ls` avait fini, alors qu'elle devrait egalement attendre `sleep 1`, et donc durer 1 seconde